### PR TITLE
Collision detection for Jackal robot (+simsetup)

### DIFF
--- a/nav2_bringup/launch/navigation_launch.py
+++ b/nav2_bringup/launch/navigation_launch.py
@@ -46,7 +46,8 @@ def generate_launch_description():
                        'behavior_server',
                        'bt_navigator',
                        'waypoint_follower',
-                       'velocity_smoother']
+                       'velocity_smoother',
+                       'collision_monitor',]
 
     # Map fully qualified names to relative ones so the node's namespace can be prepended.
     # In case of the transforms (tf), currently, there doesn't seem to be a better alternative
@@ -180,7 +181,15 @@ def generate_launch_description():
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings +
-                        [('cmd_vel', 'cmd_vel_nav'), ('cmd_vel_smoothed', 'cmd_vel')]),
+                        [('cmd_vel', 'cmd_vel_nav'), ]),
+            Node(
+                package='nav2_collision_monitor',
+                executable='collision_monitor',
+                name='collision_monitor',
+                output='screen',
+                emulate_tty=True,  # https://github.com/ros2/launch/issues/188
+                # hard code parameter state_topic to collision_monitor_state
+                parameters=[configured_params],),
             Node(
                 package='nav2_lifecycle_manager',
                 executable='lifecycle_manager',
@@ -247,6 +256,16 @@ def generate_launch_description():
                 parameters=[{'use_sim_time': use_sim_time,
                              'autostart': autostart,
                              'node_names': lifecycle_nodes}]),
+            ComposableNode(
+                package='nav2_collision_monitor',
+                plugin='nav2_collision_monitor::CollisionMonitorNode',
+                name='collision_monitor',
+                parameters=[configured_params],
+                remappings=remappings + [
+                    ('/cmd_vel', '/cmd_vel_nav'),
+                    # ('/scan', '/your/scan/topic')
+                ],
+            ),
         ],
     )
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -36,6 +36,8 @@
 #include "nav2_collision_monitor/scan.hpp"
 #include "nav2_collision_monitor/pointcloud.hpp"
 #include "nav2_collision_monitor/range.hpp"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+
 
 namespace nav2_collision_monitor
 {
@@ -204,6 +206,8 @@ protected:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
+  /// @brief Collision monitor state publisher
+  rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr state_pub_;
 
   /// @brief Whether main routine is active
   bool process_active_;

--- a/nav2_collision_monitor/package.xml
+++ b/nav2_collision_monitor/package.xml
@@ -20,6 +20,7 @@
   <depend>nav2_common</depend>
   <depend>nav2_util</depend>
   <depend>nav2_costmap_2d</depend>
+  <depend>nav2_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Modified Collision detector so it only sends messages and does not change velocity of robot. This is needed for training. If in the future we want to use the collision detection for stopping collision it is enough uncomment marked lines.
